### PR TITLE
Types: Fixed typescript issues in checkbox group

### DIFF
--- a/omui/src/components/checkbox/checkbox.tsx
+++ b/omui/src/components/checkbox/checkbox.tsx
@@ -26,15 +26,9 @@ export const CheckboxGroup = ({
   checkboxes,
   ...props
 }: CheckboxGroupProps) => {
-  const defaultValue = checkboxes
-    .map((i) => {
-      if (i.checked) return i.value;
-      return null;
-    })
-    .filter((i) => i !== null);
+  const defaultValue = checkboxes.filter((i) => i.checked).map((i) => i.value);
 
   return (
-    // @ts-ignore
     <ChakraCheckboxGroup {...props} defaultValue={defaultValue}>
       <Stack
         spacing={direction === 'horizontal' ? 6 : 2}
@@ -55,66 +49,3 @@ CheckboxGroup.defaultProps = {
 };
 
 CheckboxGroup.displayName = 'CheckboxGroup';
-
-// type IndeterminateCheckboxGroupProps = {
-//   checkboxes: CheckboxGroupItemProps[];
-// };
-
-// TODO: This component is not ready yet... we have some fairly complicated (recursive) state management logic to handle here
-// export const IndeterminateCheckboxGroup = ({
-//   checkboxes,
-//   ...props
-// }: IndeterminateCheckboxGroupProps) => {
-//   const determineChecks = (
-//     children: CheckboxGroupItemProps[] | undefined,
-//     checked: boolean | undefined
-//   ) => {
-//     const allChildrenChecked = children
-//       ? children.every((i) => i.checked)
-//       : false;
-//     const someChildrenChecked = children
-//       ? children.some((i) => i.checked)
-//       : false;
-
-//     const isChecked = checked || allChildrenChecked;
-//     const isIndeterminate = someChildrenChecked && !allChildrenChecked;
-
-//     return { isChecked, isIndeterminate };
-//   };
-
-//   const composeStructure = (checkboxes: CheckboxGroupItemProps) => {
-//     const { children, label, checked, ...checkboxProps } = checkboxes;
-//     const { isChecked, isIndeterminate } = determineChecks(children, checked);
-
-//     if (children) {
-//       return (
-//         <Stack spacing={2} direction="column" key={label}>
-//           <Checkbox
-//             {...checkboxProps}
-//             defaultIsChecked={isChecked}
-//             isIndeterminate={isIndeterminate}
-//           >
-//             {label}
-//           </Checkbox>
-//           <Stack spacing={2} direction="column" pl={4}>
-//             {children.map((child) => composeStructure(child))}
-//           </Stack>
-//         </Stack>
-//       );
-//     }
-
-//     return (
-//       <Checkbox
-//         {...checkboxProps}
-//         defaultIsChecked={isChecked}
-//         isIndeterminate={isIndeterminate}
-//         key={label}
-//       >
-//         {label}
-//       </Checkbox>
-//     );
-//   };
-
-//   // @ts-ignore
-//   return <Box {...props}>{composeStructure(checkboxes)}</Box>;
-// };

--- a/omui/src/components/checkbox/checkbox.tsx
+++ b/omui/src/components/checkbox/checkbox.tsx
@@ -49,3 +49,66 @@ CheckboxGroup.defaultProps = {
 };
 
 CheckboxGroup.displayName = 'CheckboxGroup';
+
+// type IndeterminateCheckboxGroupProps = {
+//   checkboxes: CheckboxGroupItemProps[];
+// };
+
+// TODO: This component is not ready yet... we have some fairly complicated (recursive) state management logic to handle here
+// export const IndeterminateCheckboxGroup = ({
+//   checkboxes,
+//   ...props
+// }: IndeterminateCheckboxGroupProps) => {
+//   const determineChecks = (
+//     children: CheckboxGroupItemProps[] | undefined,
+//     checked: boolean | undefined
+//   ) => {
+//     const allChildrenChecked = children
+//       ? children.every((i) => i.checked)
+//       : false;
+//     const someChildrenChecked = children
+//       ? children.some((i) => i.checked)
+//       : false;
+
+//     const isChecked = checked || allChildrenChecked;
+//     const isIndeterminate = someChildrenChecked && !allChildrenChecked;
+
+//     return { isChecked, isIndeterminate };
+//   };
+
+//   const composeStructure = (checkboxes: CheckboxGroupItemProps) => {
+//     const { children, label, checked, ...checkboxProps } = checkboxes;
+//     const { isChecked, isIndeterminate } = determineChecks(children, checked);
+
+//     if (children) {
+//       return (
+//         <Stack spacing={2} direction="column" key={label}>
+//           <Checkbox
+//             {...checkboxProps}
+//             defaultIsChecked={isChecked}
+//             isIndeterminate={isIndeterminate}
+//           >
+//             {label}
+//           </Checkbox>
+//           <Stack spacing={2} direction="column" pl={4}>
+//             {children.map((child) => composeStructure(child))}
+//           </Stack>
+//         </Stack>
+//       );
+//     }
+
+//     return (
+//       <Checkbox
+//         {...checkboxProps}
+//         defaultIsChecked={isChecked}
+//         isIndeterminate={isIndeterminate}
+//         key={label}
+//       >
+//         {label}
+//       </Checkbox>
+//     );
+//   };
+
+//   // @ts-ignore
+//   return <Box {...props}>{composeStructure(checkboxes)}</Box>;
+// };


### PR DESCRIPTION
## Description
Typescript types re-evaluation: `Checkbox`

- Removed `//@ts-ignore` by updating the `defaultValue` definition.
 
## Affected Dependencies
n/a

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
